### PR TITLE
 Fix the attributeaggregator patch for GakuNin mAP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,14 @@ COPY resources/php-fpm/www.conf /etc/php-fpm.d/
 RUN chgrp nginx /var/lib/php/session \
     && mkdir -p /run/php-fpm
 
-# Apply the simplesamlphp patch
+# Apply the saml2 patch
 ARG SOAP_CLIENT_PHP="simplesamlphp/vendor/simplesamlphp/saml2/src/SAML2/SOAPClient.php"
 COPY resources/${SOAP_CLIENT_PHP} /var/www/${SOAP_CLIENT_PHP}
+# Apply the simplesamlphp-module-attributeaggregator patch
+COPY resources/simplesamlphp/attributeaggregator-gakunin-cgw.patch /var/www/simplesamlphp/modules/attributeaggregator/
+RUN yum -y update && yum -y install patch && \
+    cd /var/www/simplesamlphp/modules/attributeaggregator/ && cat attributeaggregator-gakunin-cgw.patch | patch -p1 && \
+    rm attributeaggregator-gakunin-cgw.patch
 
 # Setup simplesamlphp
 RUN set -x \

--- a/resources/simplesamlphp/attributeaggregator-gakunin-cgw.patch
+++ b/resources/simplesamlphp/attributeaggregator-gakunin-cgw.patch
@@ -13,3 +13,20 @@ index 97949fa..6d9ae82 100644
  				$invalid = TRUE;
  				if ($config["nameIdFormat"] == $format) {
  					$this->nameIdFormat = $config["nameIdFormat"];
+diff --git a/www/attributequery.php b/www/attributequery.php
+index 0c27b5a..c41fe21 100644
+--- a/www/attributequery.php
++++ b/www/attributequery.php
+@@ -86,7 +86,11 @@ if ($idpEntityId === NULL) {
+ 	throw new SimpleSAML_Error_Exception('Missing issuer in response.');
+ }
+ $assertions = $response->getAssertions();
+-$attributes_from_aa = $assertions[0]->getAttributes();
++if (!empty($assertions)) {
++	$attributes_from_aa = $assertions[0]->getAttributes();
++} else {
++	$attributes_from_aa = array();
++}
+ $expected_attributes = $state['attributeaggregator:attributes'];
+ // get attributes from response, and put it in the state.
+ foreach ($attributes_from_aa as $name=>$values){

--- a/resources/simplesamlphp/attributeaggregator-gakunin-cgw.patch
+++ b/resources/simplesamlphp/attributeaggregator-gakunin-cgw.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/Auth/Process/attributeaggregator.php b/lib/Auth/Process/attributeaggregator.php
+index 97949fa..6d9ae82 100644
+--- a/lib/Auth/Process/attributeaggregator.php
++++ b/lib/Auth/Process/attributeaggregator.php
+@@ -96,7 +96,9 @@ class sspmod_attributeaggregator_Auth_Process_attributeaggregator extends Simple
+ 							SAML2_Const::NAMEID_UNSPECIFIED,
+ 							SAML2_Const::NAMEID_PERSISTENT,
+ 							SAML2_Const::NAMEID_TRANSIENT,
+-							SAML2_Const::NAMEID_ENCRYPTED) as $format) {
++							SAML2_Const::NAMEID_ENCRYPTED,
++							"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
++							"urn:oid:1.3.6.1.4.1.5923.1.1.1.6") as $format) {
+ 				$invalid = TRUE;
+ 				if ($config["nameIdFormat"] == $format) {
+ 					$this->nameIdFormat = $config["nameIdFormat"];

--- a/resources/simplesamlphp/config/config.php
+++ b/resources/simplesamlphp/config/config.php
@@ -589,7 +589,54 @@ $config = array(
             /**
              * The format of attributeId. Default is 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
              */
-            'nameIdFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+            'nameIdFormat' => 'urn:oid:1.3.6.1.4.1.5923.1.1.1.6',
+
+
+            /**
+             * The name Format of the attribute names.
+             */
+            'attributeNameFormat' => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
+
+            /**
+             * The requested attributes. If not present, we will get all
+             * the attributes. The keys of the array is the attribute name in (''urn:oid'') format.
+             * values:
+             *   the array of acceptable values. If not defined, the filter will accept all values.
+             * multiSource:
+             *   merge:    merge the existing and the new values, this is the default behaviour,
+             *   override: drop the existing values and set the values from AA,
+             *   keep:     drop the new values from AA and keep the original values.
+             */
+            'attributes' => array(
+                    "urn:oid:1.3.6.1.4.1.5923.1.5.1.1" => array (),
+            //         "urn:oid:attribute-OID-2" => array (
+            //               "multiSource" => "keep"
+            //               ),
+            //         "urn:oid:attribute-OID-3" => array (
+            //               "values" => array ("value1", "value2"),
+            //               ),
+            //         "urn:oid:attribute-OID-4" => array ()
+                   ),
+         ),
+
+        69 => array(
+            'class' => 'attributeaggregator:attributeaggregator',
+            'entityId' => 'https://cg.gakunin.jp/idp/shibboleth',
+
+            /**
+             * The subject of the attribute query. Default: urn:oid:1.3.6.1.4.1.5923.1.1.1.6 (eduPersonPrincipalName)
+             */
+            'attributeId' => 'urn:oid:0.9.2342.19200300.100.1.3',
+
+            /**
+             * If set to TRUE, the module will throw an exception if attributeId is not found.
+             */
+            'required' => FALSE,
+
+            /**
+             * The format of attributeId. Default is 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+             */
+            'nameIdFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
 
 
             /**

--- a/resources/simplesamlphp/vendor/simplesamlphp/saml2/src/SAML2/SOAPClient.php
+++ b/resources/simplesamlphp/vendor/simplesamlphp/saml2/src/SAML2/SOAPClient.php
@@ -104,9 +104,6 @@ class SAML2_SOAPClient
         $x = new SoapClient(NULL, $options);
 
         // Add soap-envelopes
-        $nameId = $msg->getNameId();
-        $nameId['Format'] = 'urn:oid:1.3.6.1.4.1.5923.1.1.1.6';
-        $msg->setNameId($nameId);
         $request = $msg->toSignedXML();
         $request = self::START_SOAP_ENVELOPE . $request->ownerDocument->saveXML($request) . self::END_SOAP_ENVELOPE;
 


### PR DESCRIPTION
This PR makes the nameIdFormat configurable and allows empty assertions in attribute query responses.