### PR TITLE
Specify only TLSv1.2 for ssl_protocols

### DIFF
--- a/resources/nginx/idp-proxy.conf
+++ b/resources/nginx/idp-proxy.conf
@@ -8,6 +8,7 @@ server {
 
   ssl_certificate "/etc/pki/nginx/idp-proxy.chained.cer";
   ssl_certificate_key "/etc/pki/nginx/private/idp-proxy.key";
+  ssl_protocols TLSv1.2;
 
   location / {
     try_files $uri $uri/ /index.php?$query_string;


### PR DESCRIPTION
Specify TLSv1.2 for ssl_protocols to reject TLSv1 and TLSv1.1