### PR TITLE
Switch the base image to rockylinux/rockylinux:9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux:9
+FROM rockylinux/rockylinux:9
 
 ARG SIMPLESAMLPHP_VERSION="2.4.4"
 ARG ATTRIBUTE_AGGREGATOR_URL="https://github.com/NII-cloud-operation/simplesamlphp-module-attributeaggregator"


### PR DESCRIPTION
There are no updates available for rockylinux:9.